### PR TITLE
Replace level title with level-selection dropdown in editor

### DIFF
--- a/ImportExport.js
+++ b/ImportExport.js
@@ -77,6 +77,7 @@ function resetUIValuesInTool() {
   tileMapHandler.currentLevel = 1;
   tileMapHandler.resetLevel(tileMapHandler.currentLevel);
   LevelNavigationHandler.updateLevel();
+  LevelNavigationHandler.adaptLevelList();
   PlayerAttributesHandler.sliderValues.forEach(sliderValue => {
       sliderValue !== "maxJumpFrames" && PlayerAttributesHandler.setInitialSliderValue(sliderValue);
   })

--- a/handlers/LevelNavigationHandler.js
+++ b/handlers/LevelNavigationHandler.js
@@ -2,11 +2,12 @@ class LevelNavigationHandler {
 
     static staticConstructor() {
         this.createNewLevelButton = document.getElementById("createNewLevelButton");
-        this.currentLevelTitle = document.getElementById("currentLevel");
+        this.levelListDropdown = document.getElementById("levelListDropdown");
         this.levelSizeButton = document.getElementById("levelSizeButton");
         this.levelHelpersButton = document.getElementById("levelHelpersButton")
         this.copyNotification = document.getElementById("copyNotification");
         this.adaptVisibilityOfButtons();
+        this.adaptLevelList();
         this.copiedLevel = {};
     }
 
@@ -17,6 +18,11 @@ class LevelNavigationHandler {
         this.adjustObjectsToAddedLevel(nextLevel);
         this.adjustEffectsAfterLevelAmountChange(nextLevel);
         this.updateLevel();
+        this.handleChangeLevelList();
+    }
+
+    static handleChangeLevelList() {
+        this.adaptLevelList();
         this.adaptVisibilityOfButtons();
     }
 
@@ -52,22 +58,28 @@ class LevelNavigationHandler {
         })
     }
 
-    static switchToLevel(changeBy) {
-        //If level was switched via GUI, not by player winning a level
+    static incrementLevel(changeBy) {
+        let nextLevel = tileMapHandler.currentLevel + changeBy;
+        if (nextLevel < 0) {
+            nextLevel = 0;
+        }
+        if (nextLevel > WorldDataHandler.levels.length - 1) {
+            nextLevel = WorldDataHandler.levels.length - 1;
+        }
+
+        this.selectLevel(nextLevel);
+    }
+
+    static selectLevel(levelIndex) {
+        if (levelIndex == tileMapHandler.currentLevel) {
+            return;
+        }
         PlayMode.currentPauseFrames = 0;
 
-        let currentLevel = tileMapHandler.currentLevel + changeBy;
-        if (currentLevel < 0) {
-            currentLevel = 0;
-        }
-        if (currentLevel > WorldDataHandler.levels.length - 1) {
-            currentLevel = WorldDataHandler.levels.length - 1;
-        }
-        if (currentLevel != tileMapHandler.currentLevel) {
-            tileMapHandler.currentLevel = currentLevel;
-            this.updateLevel();
-        }
-
+        this.levelListDropdown.value = levelIndex;
+        tileMapHandler.currentLevel = levelIndex;
+        this.updateLevel();
+        
         this.adaptVisibilityOfButtons();
     }
 
@@ -95,16 +107,29 @@ class LevelNavigationHandler {
         }
     }
 
+    static adaptLevelList() {
+        while (this.levelListDropdown.firstChild) {
+            this.levelListDropdown.removeChild(this.levelListDropdown.lastChild);
+        }
+        WorldDataHandler.levels.forEach((level, levelIndex) => {
+            let optElem = document.createElement("option");
+            let title = "Level " + levelIndex;
+            if (levelIndex == 0) {
+                title = "Start Screen";
+            }
+            else if (levelIndex == WorldDataHandler.levels.length - 1) {
+                title = "Ending Screen";
+            }
+            optElem.textContent = title;
+            optElem.value = levelIndex;
+            this.levelListDropdown.appendChild(optElem);
+        });
+
+        this.levelListDropdown.value = tileMapHandler.currentLevel;
+    }
+
     static updateLevel() {
-        let levelTitle = "Level " + (tileMapHandler.currentLevel);
-        if (tileMapHandler.currentLevel === 0) {
-            levelTitle = "Start screen";
-        }
-        else if (tileMapHandler.currentLevel === WorldDataHandler.levels.length - 1) {
-            levelTitle = "Ending screen";
-        }
         this.adaptVisibilityOfButtons();
-        this.currentLevelTitle.innerHTML = levelTitle;
         tileMapHandler.resetLevel(tileMapHandler.currentLevel);
     }
 
@@ -145,7 +170,7 @@ class LevelNavigationHandler {
             WorldDataHandler.levels.splice(currentLevel, 1);
             this.adjustEffectsAfterLevelAmountChange(currentLevel, "deleted")
             this.updateLevel();
-            this.adaptVisibilityOfButtons();
+            this.handleChangeLevelList();
             ModalHandler.closeModal('deleteLevelModal');
         }
         else {

--- a/handlers/TileMapHandler.js
+++ b/handlers/TileMapHandler.js
@@ -234,6 +234,7 @@ class TileMapHandler {
             this.resetLevel(this.currentLevel);
             if (typeof LevelNavigationHandler === 'function') {
                 LevelNavigationHandler.updateLevel();
+                LevelNavigationHandler.adaptLevelList();
             }
         }
         else {

--- a/index.html
+++ b/index.html
@@ -148,11 +148,13 @@
                 <div class="sectionContent">
                     <div class="menuSection">
                         <div class="levelNavigation">
-                            <button class="levelNavigationButton" onClick="LevelNavigationHandler.switchToLevel(-1)">
+                            <button class="levelNavigationButton" onClick="LevelNavigationHandler.incrementLevel(-1)">
                                 <img src="images/icons/left.svg" alt="left" width="14" height="14">
                             </button>
-                            <span class="currentLevel" id="currentLevel">level 1</span>
-                            <button class="levelNavigationButton" onClick="LevelNavigationHandler.switchToLevel(1)">
+                            <select id="levelListDropdown" onchange="LevelNavigationHandler.selectLevel(parseInt(event.target.value))">
+                                <option value="0">(Loading...)</option>
+                            </select>
+                            <button class="levelNavigationButton" onClick="LevelNavigationHandler.incrementLevel(1)">
                                 <img src="images/icons/right.svg" alt="right" width="14" height="14">
                             </button>
                             <button id="createNewLevelButton" class="levelNavigationButton"

--- a/styles/gameScreen.css
+++ b/styles/gameScreen.css
@@ -201,14 +201,6 @@ details summary:hover {
     padding: 11px 10px;
 }
 
-.currentLevel {
-    display: inline-block;
-    min-width: 115px;
-    padding: 11px;
-    vertical-align: top;
-    text-align: center;
-}
-
 .playerAttrSlider {
     width: 80%;
 }


### PR DESCRIPTION
Adds a level-selection dropdown to quickly select a level to edit, instead of only using the arrow buttons.
This dropdown replaces the level title span that would normally appear between the two buttons.